### PR TITLE
Enhance viral discovery heuristics

### DIFF
--- a/core/rank.py
+++ b/core/rank.py
@@ -21,6 +21,8 @@ def load_keywords(path: str = "queries.json") -> Dict[str, set[str]]:
         KEYWORDS_CACHE = {
             "he": {s.lower() for s in config.get("keywords_he", [])},
             "en": {s.lower() for s in config.get("keywords_en", [])},
+            "artists": {s.lower() for s in config.get("artist_keywords", [])},
+            "viral": {s.lower() for s in config.get("viral_cues", [])},
             "cities": {s.lower() for s in config.get("cities", [])},
         }
         LOGGER.debug("Loaded keyword configuration", extra={"counts": {k: len(v) for k, v in KEYWORDS_CACHE.items()}})
@@ -35,6 +37,8 @@ def score_rule_based(title: str, text: str) -> float:
     hits_he = sum(1 for kw in keywords["he"] if kw in combined)
     hits_en = sum(1 for kw in keywords["en"] if kw in combined)
     hits_city = sum(1 for city in keywords["cities"] if city in combined)
+    hits_artist = sum(1 for artist in keywords["artists"] if artist in combined)
+    hits_viral = sum(1 for clue in keywords["viral"] if clue in combined)
 
     if hits_he == 0 and hits_en == 0:
         score -= 3.0
@@ -42,7 +46,9 @@ def score_rule_based(title: str, text: str) -> float:
         score += hits_he * 2.0
         score += hits_en * 1.4
 
-    score += hits_city * 1.0
+    score += hits_city * 1.2
+    score += hits_artist * 2.5
+    score += hits_viral * 1.5
 
     if re.search(r"\b(today|tonight|this week|tomorrow|היום|הלילה|השבוע|מחר)\b", combined):
         score += 1.8
@@ -64,6 +70,8 @@ def score_rule_based(title: str, text: str) -> float:
             "hits_he": hits_he,
             "hits_en": hits_en,
             "hits_city": hits_city,
+            "hits_artist": hits_artist,
+            "hits_viral": hits_viral,
         },
     )
     return score

--- a/queries.json
+++ b/queries.json
@@ -13,7 +13,16 @@
     "סטודנטים",
     "After",
     "ליין-אפ",
-    "הופעה"
+    "הופעה",
+    "ליין-אפ",
+    "הפקה",
+    "אירוע",
+    "סט",
+    "ליינאפ",
+    "טראק",
+    "במה",
+    "וויב",
+    "חגיגה"
   ],
   "keywords_en": [
     "festival",
@@ -24,7 +33,45 @@
     "EDM",
     "lineup",
     "DJ set",
-    "after party"
+    "after party",
+    "headline set",
+    "stage takeover",
+    "live act",
+    "party",
+    "banger",
+    "viral"
+  ],
+  "artist_keywords": [
+    "אדם טן",
+    "מיטה גאמי",
+    "מיטגאמי",
+    "קלאב דה קומבט",
+    "club de combat",
+    "adam ten",
+    "mita gami",
+    "solomun",
+    "solomon",
+    "black coffee",
+    "keinemusik",
+    "eden pines",
+    "אושר כהן",
+    "עידן בקשי",
+    "mako",
+    "celebs"
+  ],
+  "viral_cues": [
+    "קליפ",
+    "ויראלי",
+    "סרטון",
+    "הדלפה",
+    "כותרות",
+    "מכות",
+    "דרמה",
+    "טרנד",
+    "trend",
+    "viral",
+    "headline",
+    "must watch"
   ],
   "cities": [
     "תל אביב",
@@ -34,7 +81,12 @@
     "נתניה",
     "אילת",
     "TLV",
-    "Tel Aviv"
+    "Tel Aviv",
+    "קיסריה",
+    "הר החרמון",
+    "ים המלח",
+    "צפון",
+    "דרום"
   ],
   "google_news_queries": [
     "פסטיבל site:il",
@@ -42,7 +94,14 @@
     "EDM Israel",
     "טכנו ישראל",
     "Hip hop Israel club",
-    "festival Israel"
+    "festival Israel",
+    "אדם טן הופעה",
+    "מיטה גאמי סט",
+    "קיינמוזיק ישראל",
+    "אושר כהן הופעה",
+    "טרה פסטיבל",
+    "Solomun Israel",
+    "Black Coffee Tel Aviv"
   ],
   "rss_feeds": [
     "https://news.google.com/rss/search?q=%D7%A4%D7%A1%D7%98%D7%99%D7%91%D7%9C%20when:7d&hl=iw&gl=IL&ceid=IL:iw",

--- a/tests/test_rank.py
+++ b/tests/test_rank.py
@@ -13,3 +13,10 @@ def test_score_rule_based_penalises_missing_keywords():
     text = "Today we discuss earnings and politics in Jerusalem."
     score = score_rule_based(title, text)
     assert score < 0
+
+
+def test_score_rule_based_recognises_viral_artist_mentions():
+    title = "אדם טן משחרר טראק חדש בקיסריה"
+    text = "הקליפ הויראלי של Adam Ten מתעד לילה מטורף ב-Club de Combat."
+    score = score_rule_based(title, text)
+    assert score > 4


### PR DESCRIPTION
## Summary
- expand the keyword and query configuration with Israeli artists, viral cues, and additional city coverage to surface more relevant party clips
- boost the rule-based ranking by rewarding artist and virality mentions alongside city hits for better prioritisation
- add a regression test ensuring viral artist combinations receive higher scores

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d6c1b6d940832bb5693ba12423caeb