### PR TITLE
Refine Reddit sourcing to surface scoops and videos

### DIFF
--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -1,4 +1,5 @@
 from sources.google_news import _extract_direct_link
+from sources.reddit import _looks_like_scoop, _looks_like_video
 
 
 def test_extract_direct_link_returns_original_for_non_google():
@@ -12,3 +13,12 @@ def test_extract_direct_link_strips_google_redirect():
     )
     expected = "https://foo.bar"
     assert _extract_direct_link(url) == expected
+
+
+def test_reddit_video_detection_by_domain():
+    payload = {"domain": "v.redd.it", "post_hint": "hosted:video"}
+    assert _looks_like_video(payload, "https://v.redd.it/clip")
+
+
+def test_reddit_scoop_detection_keywords():
+    assert _looks_like_scoop("Breaking: New lineup announced for Tel Aviv")


### PR DESCRIPTION
## Summary
- require Reddit results to look like either viral videos or scoop-style announcements before keeping them
- add heuristics for video domains/post hints and scoop keywords to the Reddit fetcher
- cover the new helpers with unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d6c75153a8832ba12a52d0b988dff7