### PR TITLE
Add TikTok hashtag sourcing via TikWM

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # EventScout AI — No YouTube API Needed
 
-EventScout monitors free data sources (Google News RSS, curated RSS feeds, Reddit JSON) → extracts article text and videos → ranks candidates with heuristics or an optional LLM → sends the best leads to Telegram.
+EventScout monitors free data sources (Google News RSS, curated RSS feeds, Reddit JSON, TikTok search via TikWM) → extracts article text and videos → ranks candidates with heuristics or an optional LLM → sends the best leads to Telegram.
 
 ## Why it is free
 - No YouTube API.
 - Google News RSS and open RSS feeds.
 - Public Reddit JSON (mind the rate limits).
+- TikTok search via the free [TikWM](https://www.tikwm.com/) API.
 - Optional: local LLM via [Ollama](https://ollama.com).
 
 ## Installation
@@ -29,6 +30,7 @@ Edit `queries.json`:
 - `google_news_queries`: search strings (the tool builds RSS URLs automatically).
 - `rss_feeds`: direct feeds for event or production sites.
 - `subreddits`: EDM/festival sources.
+- `tiktok_hashtags`: hashtags or keywords to look up on TikTok (7-day window, sorted by engagement).
 - `keywords_*` + `cities`: keywords for scoring.
 
 ## Run the bot

--- a/bot.py
+++ b/bot.py
@@ -18,6 +18,7 @@ from core.utils import hash_id, load_seen, norm_text, save_seen
 from sources.google_news import fetch_search
 from sources.reddit import fetch_subreddit
 from sources.rss import fetch_rss
+from sources.tiktok import fetch_hashtag
 
 LOGGER = logging.getLogger("eventscout")
 
@@ -95,6 +96,20 @@ def collect_candidates(qconf: Dict, *, max_per_source: int = 10) -> List[dict]:
                     seen_links.add(result["link"])
         except Exception:
             LOGGER.exception("Failed to fetch subreddit", extra={"subreddit": subreddit})
+
+    for hashtag in qconf.get("tiktok_hashtags", []):
+        try:
+            results = fetch_hashtag(hashtag, limit=max_per_source, days=7)
+            LOGGER.debug(
+                "TikTok results",
+                extra={"hashtag": hashtag, "count": len(results)},
+            )
+            for result in results:
+                if result["link"] not in seen_links:
+                    items.append(result)
+                    seen_links.add(result["link"])
+        except Exception:
+            LOGGER.exception("Failed to fetch TikTok hashtag", extra={"hashtag": hashtag})
 
     LOGGER.info("Collected %s unique raw candidates", len(items))
     return items

--- a/queries.json
+++ b/queries.json
@@ -112,5 +112,13 @@
     "festivals",
     "electronicmusic",
     "hiphopheads"
+  ],
+  "tiktok_hashtags": [
+    "TelAvivParty",
+    "IsraelNightlife",
+    "EDMIsrael",
+    "TelAvivClub",
+    "IsraelRave",
+    "HaifaParty"
   ]
 }

--- a/sources/tiktok.py
+++ b/sources/tiktok.py
@@ -1,0 +1,160 @@
+"""TikTok hashtag search utilities using the public TikWM API."""
+from __future__ import annotations
+
+import datetime as dt
+import logging
+from typing import Iterable, List
+
+import requests
+
+_LOGGER = logging.getLogger(__name__)
+_API_ENDPOINT = "https://www.tikwm.com/api/search"
+
+
+def _parse_timestamp(value: object) -> dt.datetime | None:
+    """Parse TikTok timestamps into aware ``datetime`` objects."""
+    if value in (None, "", 0):
+        return None
+    try:
+        numeric = int(value)
+    except (TypeError, ValueError):
+        return None
+    try:
+        return dt.datetime.fromtimestamp(numeric, tz=dt.timezone.utc)
+    except (OverflowError, OSError, ValueError):
+        return None
+
+
+def _coerce_title(video: dict) -> str | None:
+    candidates: Iterable[str | None] = (
+        video.get("title"),
+        video.get("desc"),
+        video.get("description"),
+    )
+    for candidate in candidates:
+        if candidate:
+            return str(candidate).strip()
+    author = video.get("author") or {}
+    username = None
+    if isinstance(author, dict):
+        username = author.get("unique_id") or author.get("nickname")
+    if username:
+        return f"TikTok by @{username}"
+    return None
+
+
+def _coerce_share_url(video: dict) -> str | None:
+    candidates: Iterable[str | None] = (
+        video.get("share_url"),
+        video.get("play"),
+        video.get("url"),
+        video.get("video_url"),
+    )
+    for candidate in candidates:
+        if candidate:
+            text = str(candidate).strip()
+            if text:
+                return text
+    return None
+
+
+def _normalize_video(video: dict) -> dict | None:
+    link = _coerce_share_url(video)
+    if not link:
+        return None
+    title = _coerce_title(video)
+    if not title:
+        title = "TikTok video"
+    created_at = _parse_timestamp(video.get("create_time"))
+    normalized = {
+        "title": f"[TikTok] {title}",
+        "link": link,
+        "created_at": created_at,
+        "play_count": video.get("play_count"),
+        "digg_count": video.get("digg_count"),
+    }
+    return normalized
+
+
+def fetch_hashtag(
+    keyword: str,
+    *,
+    limit: int = 8,
+    days: int = 7,
+) -> List[dict]:
+    """Fetch recent TikToks for a hashtag or keyword.
+
+    The implementation relies on the free TikWM API which provides search results
+    for TikTok without authentication. Results are filtered to roughly match the
+    requested timeframe, prioritising higher engagement clips first.
+    """
+
+    cutoff = dt.datetime.now(dt.timezone.utc) - dt.timedelta(days=days)
+    params = {
+        "keywords": keyword,
+        "count": max(limit * 3, 24),
+        "page": 1,
+    }
+    _LOGGER.debug("Fetching TikTok search", extra={"keyword": keyword, "params": params})
+    try:
+        response = requests.get(_API_ENDPOINT, params=params, timeout=20)
+        response.raise_for_status()
+        payload = response.json()
+    except Exception:
+        _LOGGER.exception("Failed to fetch TikTok search", extra={"keyword": keyword})
+        return []
+
+    data = payload.get("data") if isinstance(payload, dict) else None
+    if not isinstance(data, dict):
+        _LOGGER.debug("TikTok payload missing data", extra={"keyword": keyword})
+        return []
+
+    videos: Iterable[dict] = []
+    if isinstance(data.get("videos"), list):
+        videos = data["videos"]
+    elif isinstance(data.get("list"), list):
+        videos = data["list"]
+
+    normalized: List[dict] = []
+    for raw in videos:
+        if not isinstance(raw, dict):
+            continue
+        item = _normalize_video(raw)
+        if not item:
+            continue
+        created = item["created_at"]
+        if created and created < cutoff:
+            continue
+        normalized.append(item)
+
+    normalized.sort(
+        key=lambda item: (
+            item.get("play_count") or 0,
+            item.get("digg_count") or 0,
+            item.get("created_at") or dt.datetime.min.replace(tzinfo=dt.timezone.utc),
+        ),
+        reverse=True,
+    )
+
+    results: List[dict] = []
+    for item in normalized:
+        payload = {
+            "title": item["title"],
+            "link": item["link"],
+        }
+        created = item.get("created_at")
+        if isinstance(created, dt.datetime):
+            payload["created_at"] = created.isoformat()
+        if item.get("play_count") is not None:
+            payload["play_count"] = item["play_count"]
+        if item.get("digg_count") is not None:
+            payload["digg_count"] = item["digg_count"]
+        results.append(payload)
+        if len(results) >= limit:
+            break
+
+    _LOGGER.info("Fetched %s TikTok items", len(results), extra={"keyword": keyword})
+    return results
+
+
+__all__ = ["fetch_hashtag", "_normalize_video", "_parse_timestamp"]

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -1,5 +1,8 @@
+import datetime as dt
+
 from sources.google_news import _extract_direct_link
 from sources.reddit import _looks_like_scoop, _looks_like_video
+from sources.tiktok import _normalize_video, _parse_timestamp, fetch_hashtag
 
 
 def test_extract_direct_link_returns_original_for_non_google():
@@ -22,3 +25,59 @@ def test_reddit_video_detection_by_domain():
 
 def test_reddit_scoop_detection_keywords():
     assert _looks_like_scoop("Breaking: New lineup announced for Tel Aviv")
+
+
+def test_tiktok_parse_timestamp_handles_string():
+    moment = _parse_timestamp("1700000000")
+    assert isinstance(moment, dt.datetime)
+    assert moment.tzinfo == dt.timezone.utc
+
+
+def test_tiktok_normalize_requires_link():
+    video = {"title": "Cool", "create_time": 1700000000}
+    assert _normalize_video(video) is None
+
+
+def test_fetch_hashtag_filters_old(monkeypatch):
+    class DummyResponse:
+        def __init__(self, payload):
+            self._payload = payload
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return self._payload
+
+    recent = int(dt.datetime.now(dt.timezone.utc).timestamp())
+    old = int((dt.datetime.now(dt.timezone.utc) - dt.timedelta(days=10)).timestamp())
+
+    payload = {
+        "data": {
+            "videos": [
+                {
+                    "title": "Fresh clip",
+                    "share_url": "https://www.tiktok.com/@foo/video/1",
+                    "create_time": recent,
+                    "play_count": 1000,
+                    "digg_count": 50,
+                },
+                {
+                    "title": "Old clip",
+                    "share_url": "https://www.tiktok.com/@foo/video/2",
+                    "create_time": old,
+                    "play_count": 999999,
+                },
+            ]
+        }
+    }
+
+    def fake_get(url, params, timeout):
+        assert "keywords" in params
+        return DummyResponse(payload)
+
+    monkeypatch.setattr("sources.tiktok.requests.get", fake_get)
+
+    results = fetch_hashtag("club", limit=3, days=7)
+    assert len(results) == 1
+    assert results[0]["link"].endswith("/video/1")


### PR DESCRIPTION
## Summary
- add a TikTok hashtag source powered by the free TikWM API and hook it into candidate collection
- document the new configuration and default hashtag list for TikTok discovery
- add unit coverage for TikTok timestamp parsing, normalization, and time filtering

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d7b3fafd1c832ba476f9d270bab1ff