### PR TITLE
Improve event relevance and TikTok sourcing

### DIFF
--- a/queries.json
+++ b/queries.json
@@ -5,6 +5,9 @@
     "מסיבת נוער",
     "טכנו",
     "היפ הופ",
+    "פופ",
+    "רוק",
+    "ג'אז",
     "EDM",
     "רחבה",
     "ליין",
@@ -22,7 +25,9 @@
     "טראק",
     "במה",
     "וויב",
-    "חגיגה"
+    "חגיגה",
+    "מופע",
+    "בידור"
   ],
   "keywords_en": [
     "festival",
@@ -30,6 +35,9 @@
     "club night",
     "techno",
     "hip hop",
+    "pop",
+    "rock",
+    "jazz",
     "EDM",
     "lineup",
     "DJ set",
@@ -39,7 +47,9 @@
     "live act",
     "party",
     "banger",
-    "viral"
+    "viral",
+    "concert",
+    "live show"
   ],
   "artist_keywords": [
     "אדם טן",
@@ -57,7 +67,9 @@
     "אושר כהן",
     "עידן בקשי",
     "mako",
-    "celebs"
+    "celebs",
+    "ישראל בידור",
+    "israel bidur"
   ],
   "viral_cues": [
     "קליפ",
@@ -71,7 +83,11 @@
     "trend",
     "viral",
     "headline",
-    "must watch"
+    "must watch",
+    "רכילות",
+    "celeb",
+    "celebs",
+    "bidur"
   ],
   "cities": [
     "תל אביב",
@@ -119,6 +135,14 @@
     "EDMIsrael",
     "TelAvivClub",
     "IsraelRave",
-    "HaifaParty"
+    "HaifaParty",
+    "MakoCelebs",
+    "mako celebs",
+    "ישראל בידור",
+    "israel bidur",
+    "ישראלבידור",
+    "מסיבות בישראל",
+    "חיי לילה",
+    "live concert israel"
   ]
 }

--- a/sources/reddit.py
+++ b/sources/reddit.py
@@ -17,11 +17,63 @@ SCOOP_KEYWORDS = {
     "exclusive",
     "reveals",
     "revealed",
-    "new track",
-    "new single",
-    "new album",
     "tour dates",
     "lineup",
+    "set times",
+    "tickets",
+    "ticket",
+    "afterparty",
+    "festival",
+    "concert",
+    "party",
+    "show",
+    "performance",
+}
+
+EVENT_KEYWORDS = {
+    "festival",
+    "fest",
+    "concert",
+    "concerts",
+    "show",
+    "shows",
+    "gig",
+    "gigs",
+    "tour",
+    "tour dates",
+    "party",
+    "parties",
+    "event",
+    "events",
+    "lineup",
+    "set times",
+    "dj",
+    "dj set",
+    "set",
+    "club",
+    "nightlife",
+    "rave",
+    "live",
+    "performance",
+    "headline",
+    "afterparty",
+    "מסיבה",
+    "מסיבות",
+    "פסטיבל",
+    "פסטיבלים",
+    "הופעה",
+    "הופעות",
+    "אירוע",
+    "אירועים",
+    "ליין",
+    "ליינאפ",
+    "סט",
+    "טכנו",
+    "די ג'יי",
+    "דיג'יי",
+    "חיי לילה",
+    "בידור",
+    "מופע",
 }
 
 VIDEO_HINTS = {"hosted:video", "rich:video", "video"}
@@ -74,9 +126,11 @@ def fetch_subreddit(subreddit: str, *, limit: int = 10, t: str = "day") -> List[
         if score < 20 and num_comments < 3:
             # Filter low-signal posts to reduce noise.
             continue
-        if not (_looks_like_video(payload, link) or _looks_like_scoop(title)):
+        is_video = _looks_like_video(payload, link)
+        is_eventful = _looks_eventful(title)
+        if not (is_video or is_eventful or _looks_like_scoop(title)):
             _LOGGER.debug(
-                "Skipping subreddit post without scoop/video cues",
+                "Skipping subreddit post without event/video cues",
                 extra={"title": title[:80], "link": link},
             )
             continue
@@ -111,4 +165,9 @@ def _looks_like_scoop(title: str) -> bool:
     return any(token in normalized for token in SCOOP_KEYWORDS)
 
 
-__all__ = ["fetch_subreddit"]
+def _looks_eventful(title: str) -> bool:
+    normalized = title.lower()
+    return any(token in normalized for token in EVENT_KEYWORDS)
+
+
+__all__ = ["fetch_subreddit", "_looks_eventful"]

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -1,7 +1,7 @@
 import datetime as dt
 
 from sources.google_news import _extract_direct_link
-from sources.reddit import _looks_like_scoop, _looks_like_video
+from sources.reddit import _looks_eventful, _looks_like_scoop, _looks_like_video
 from sources.tiktok import _normalize_video, _parse_timestamp, fetch_hashtag
 
 
@@ -25,6 +25,10 @@ def test_reddit_video_detection_by_domain():
 
 def test_reddit_scoop_detection_keywords():
     assert _looks_like_scoop("Breaking: New lineup announced for Tel Aviv")
+
+
+def test_reddit_eventful_detection_keywords():
+    assert _looks_eventful("Huge techno festival takes over Tel Aviv coastline")
 
 
 def test_tiktok_parse_timestamp_handles_string():


### PR DESCRIPTION
## Summary
- broaden the Hebrew and English keyword configuration to cover more music genres, celeb chatter, and TikTok search terms tied to Israeli nightlife
- tighten Reddit filtering by focusing scoop keywords on event news and requiring video or event-related language
- add a unit test to confirm the new eventful keyword detector catches festival headlines

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d7b6e41f70832ba79448cb5fa16815